### PR TITLE
set up shared folder and ssh forwarding

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -4,5 +4,10 @@
 Vagrant.configure(2) do |config|
   config.vm.box = "ubuntu/trusty64"
 
-	config.vm.synced_folder "src/", "/home/vagrant", create: true
+	config.vm.synced_folder "src/", "/home/vagrant/src/", create: true
+
+	config.ssh.private_key_path = ["~/.vagrant.d/insecure_private_key", "~/.ssh/id_rsa"]
+	config.ssh.forward_agent = true
+
+	config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: ".ssh/id_rsa.pub"
 end


### PR DESCRIPTION
set up ssh forward agent, and created 'src' folder in both the host and the
guest. /home/vagrant cannot be synced with another folder in host, as the
vagrant user must control permissions on that folder. See:

http://stackoverflow.com/questions/23599297/changing-vagrantfile-causes-vagrant-ssh-to-prompt-for-a-password

closes #5, 'ask for auth on reload'
