### PR TITLE
provision dotfiles

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,12 +10,16 @@ Vagrant.configure(2) do |config|
 	config.ssh.forward_agent = true
 
 	config.vm.provision "file", source: "~/.ssh/id_rsa.pub", destination: ".ssh/id_rsa.pub"
+	config.vm.provision "file", source: "~/.gitconfig", destination: ".gitconfig"
+	config.vm.provision "file", source: "~/_vimrc", destination: ".vimrc"
 
 	config.vm.provision "shell", path: "shell/setup.sh"
 	config.vm.provision "shell", 
 		:inline =>	"echo 'Turning off console beeps...' && "\
 								"grep '^set bell-style none' /etc/inputrc || "\
 								"echo 'set bell-style none' >> /etc/inputrc"	
+
+	config.vm.provision "shell", path: "shell/endings.sh"
 
 	config.vm.provider :virtualbox do |vb|
 		vb.customize ["modifyvm", :id, "--natdnshostresolver1", "on"]

--- a/shell/endings.sh
+++ b/shell/endings.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+dos2unix .gitconfig
+dos2unix .vimrc

--- a/shell/setup.sh
+++ b/shell/setup.sh
@@ -2,4 +2,4 @@
 
 apt-get update
 
-apt-get install -y git
+apt-get install -y git dos2unix


### PR DESCRIPTION
use file provisioning to upload .vimrc and .gitconfig to guest. install
dos2unix. add script to run dos2unix on dotfiles to get rid of CRLF endings.

closes #13
