### PR TITLE
added info about ssh key to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,7 @@
 2. Install [VirtualBox](https://www.virtualbox.org/)
 
 3. Install [Vagrant](https://www.vagrantup.com/)
+
+4. Follow instructions [here](https://help.github.com/articles/generating-ssh-keys/) to generate a keypair. For now, be sure the key is named `id_rsa.pub` and stored in `~/.ssh/`, or modify the Vagrantfile to point to the correct key.
+
+5. Follow instructions [here](https://help.github.com/articles/working-with-ssh-key-passphrases/) to auto-launch ssh-agent.


### PR DESCRIPTION
for now, I just linked to the instructions on github on generating a keypair,
and auto-launching ssh-agent. currently the name and location of the key is
not configureble. be sure to do that later.

closes #12
